### PR TITLE
Unit Testing Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 elm-stuff/
+test/elm-stuff/

--- a/elm-package.json
+++ b/elm-package.json
@@ -7,7 +7,8 @@
         "src"
     ],
     "exposed-modules": [
-        "Hue"
+        "Hue",
+        "Hue.Lights"
     ],
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v < 5.0.0",

--- a/src/Hue/Lights.elm
+++ b/src/Hue/Lights.elm
@@ -1,0 +1,67 @@
+module Hue.Lights exposing (LightDetails, LightState, LightEffect(..), Alert(..))
+
+{-| Hue Light Types
+
+## Representing Light Details
+@docs LightDetails
+
+## Representing Light State
+@docs LightState, LightEffect, Alert
+-}
+
+
+{-| Details about a light like identifier, software version and bulb type.
+-}
+type alias LightDetails =
+    { id : String
+    , name : String
+    , uniqueId : String
+    , bulbType : String
+    , modelId : String
+    , manufacturerName : String
+    , softwareVersion : String
+    }
+
+
+{-| Describes the current state of a light.
+
+ - `on`: is this light turned on?
+ - `brightness`: a range from `1` (minimal brightness) to `254` (maximal brightness)
+ - `hue`: a range from `0` to `65535`, with both of them resulting in red, `25500` in green and
+   `46920` in blue
+ - `saturation`: range from `0` (white) to `254` (fully colored)
+ - `colorTemperature`: The Mired Color temperature
+ - `reachable`: is the light reachable?
+-}
+type alias LightState =
+    { on : Bool
+    , brightness : Int
+    , hue : Int
+    , saturation : Int
+    , effect : LightEffect
+    , colorTemperature : Int
+    , alert : Alert
+    , reachable : Bool
+    }
+
+
+{-| A light can have the `ColorLoopEffect` enabled, which means that the light will cycle through
+all hues, while keeping brightness and saturation values.
+-}
+type LightEffect
+    = NoLightEffect
+    | ColorLoopEffect
+
+
+{-| A temporary change to a light's state.
+
+ - `NoAlert`: Disable any existing alerts.
+ - `SingleAlert`: The light will perform a single, smooth transition up to a higher brightness and
+   back to the original again.
+ - `LoopedAlert`: The light will perform multiple, smooth transitions up to a higher brightness and
+   back to the original again for a period of `15` seconds.
+-}
+type Alert
+    = NoAlert
+    | SingleAlert
+    | LoopedAlert

--- a/src/Hue/Lights/Decoders.elm
+++ b/src/Hue/Lights/Decoders.elm
@@ -1,0 +1,74 @@
+module Hue.Lights.Decoders exposing (..)
+
+import Hue.Lights as Lights
+import Json.Decode as JD
+import Json.Decode exposing ((:=))
+
+
+detailsDecoder : JD.Decoder Lights.LightDetails
+detailsDecoder =
+    JD.object7
+        Lights.LightDetails
+        (JD.succeed "")
+        ("name" := JD.string)
+        ("uniqueid" := JD.string)
+        ("type" := JD.string)
+        ("modelid" := JD.string)
+        ("manufacturername" := JD.string)
+        ("swversion" := JD.string)
+
+
+detailsListDecoder : JD.Decoder (List Lights.LightDetails)
+detailsListDecoder =
+    JD.keyValuePairs detailsDecoder |> JD.map (List.map (\( id, m ) -> { m | id = id }))
+
+
+stateDecoder : JD.Decoder Lights.LightState
+stateDecoder =
+    JD.object8
+        Lights.LightState
+        (JD.at [ "state", "on" ] JD.bool)
+        (JD.at [ "state", "bri" ] JD.int)
+        (JD.at [ "state", "hue" ] JD.int)
+        (JD.at [ "state", "sat" ] JD.int)
+        (JD.at [ "state", "effect" ] effectDecoder)
+        (JD.at [ "state", "ct" ] JD.int)
+        (JD.at [ "state", "alert" ] alertDecoder)
+        (JD.at [ "state", "reachable" ] JD.bool)
+
+
+effectDecoder : JD.Decoder Lights.LightEffect
+effectDecoder =
+    JD.map
+        (\x ->
+            case x of
+                "none" ->
+                    Lights.NoLightEffect
+
+                "colorloop" ->
+                    Lights.ColorLoopEffect
+
+                _ ->
+                    Debug.crash "Received unexpected light effect"
+        )
+        JD.string
+
+
+alertDecoder : JD.Decoder Lights.Alert
+alertDecoder =
+    JD.map
+        (\x ->
+            case x of
+                "none" ->
+                    Lights.NoAlert
+
+                "select" ->
+                    Lights.SingleAlert
+
+                "lselect" ->
+                    Lights.LoopedAlert
+
+                _ ->
+                    Debug.crash "Received unknown light alert"
+        )
+        JD.string

--- a/test/Test.elm
+++ b/test/Test.elm
@@ -1,0 +1,16 @@
+module Main exposing (..)
+
+import ElmTest exposing (..)
+import Tests.Lights as Lights
+
+
+tests : Test
+tests =
+    suite "Elm Hue Library Tests"
+        [ Lights.tests
+        ]
+
+
+main : Program Never
+main =
+    runSuiteHtml tests

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0",
+    "summary": "Unit tests for elm-hue",
+    "repository": "https://github.com/damienklinnert/elm-hue.git",
+    "license": "MIT",
+    "source-directories": [
+        "../src",
+        "res",
+        "test",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
+        "elm-lang/core": "4.0.0 <= v < 5.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}

--- a/test/res/Lights.elm
+++ b/test/res/Lights.elm
@@ -1,0 +1,71 @@
+module Res.Lights exposing (..)
+
+getAllLights__1_0 : String
+getAllLights__1_0 = 
+    """
+    {
+        "1": {
+            "state": {
+                "on": true,
+                "bri": 144,
+                "hue": 13088,
+                "sat": 212,
+                "xy": [0.5128,0.4147],
+                "ct": 467,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "xy",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 1",
+            "modelid": "LCT001",
+            "swversion": "66009461",
+            "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+            }
+        },
+        "2": {
+            "state": {
+                "on": false,
+                "bri": 0,
+                "hue": 0,
+                "sat": 0,
+                "xy": [0,0],
+                "ct": 0,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "hs",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 2",
+            "modelid": "LCT001",
+            "swversion": "66009461",
+            "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+            }
+        }
+    }
+    """
+
+
+noLights : String
+noLights = 
+    """
+    {}
+    """

--- a/test/tests/Lights.elm
+++ b/test/tests/Lights.elm
@@ -1,0 +1,32 @@
+module Tests.Lights exposing (tests)
+
+import Json.Decode as JD
+import ElmTest exposing (..)
+import Res.Lights exposing (..)
+import Hue.Lights.Decoders exposing (..)
+
+
+tests : Test
+tests =
+    suite "Lights decoding"
+        [ getAllLightsTest
+        ]
+
+
+getAllLightsTest : Test
+getAllLightsTest =
+    let
+        testDecoder decoder str =
+            case JD.decodeString decoder str of
+                Ok _ ->
+                    pass
+
+                Err e ->
+                    fail e
+    in
+        suite "Get all lights"
+            [ test "Version 1.0 with multiple lights" <|
+                testDecoder detailsListDecoder getAllLights__1_0
+            , test "No lights available" <|
+                testDecoder detailsListDecoder noLights
+            ]


### PR DESCRIPTION
Hi, I'm a fan of this library and thought I'd try to help improve it by adding unit testing. Since the Hue Api has different versions I thought it would be nice to unit test the JSON decoders against them. 

Below is an outline of the changes I made. But please note I had to separate some things into different modules, which changed the doc structure. If that is not desired then feel free to decline this pull request. 
- Add [Elm Test](https://github.com/elm-community/elm-test) with 2 small sample unit tests
  - One passing and failing test for fetching all lights
- Move JSON decoders into a separate **non-exposed** module `Hue.Lights.Decoders` so it can be unit tested
- Move Light type into a separate **exposed** module so it can be used by the `Hue.Lights.Decoders` and `Hue` files.
  - Still exports the same type alias and opaque types as before
