### PR TITLE
Chore/example page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff/
 test/elm-stuff/
+index.html

--- a/example/LICENSE
+++ b/example/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright (c) 2016 Damien Klinnert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,0 +1,17 @@
+{
+    "version": "1.0.0",
+    "summary": "elm-hue examples",
+    "repository": "https://github.com/damienklinnert/elm-hue.git",
+    "license": "MIT",
+    "source-directories": [
+        "../src",
+        "src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "4.0.5 <= v < 5.0.0",
+        "elm-lang/html": "1.1.0 <= v < 2.0.0",
+        "evancz/elm-http": "3.0.1 <= v < 4.0.0"
+    },
+    "elm-version": "0.17.0 <= v < 0.18.0"
+}

--- a/example/src/BlinkLight.elm
+++ b/example/src/BlinkLight.elm
@@ -1,0 +1,118 @@
+-- This example queries your light details and then repeatedly blinks one light by turning it on and off.
+
+
+module Main exposing (..)
+
+import Debug
+import Html exposing (text)
+import Html.App exposing (program)
+import Task
+import Time
+import Hue
+import Hue.Lights
+
+
+-- IMPORTANT: Configure your bridge and light details here before running this program!
+
+
+baseUrl =
+    "http://192.168.1.1"
+
+
+username =
+    "D4yG2jaaJRlKWriuoeNyD25js8aJ53lslaj73DK7"
+
+
+myBridge =
+    Hue.bridgeRef baseUrl username
+
+
+myLight =
+    Hue.lightRef myBridge "3"
+
+
+
+-- This is how you list all available lights
+
+
+listLightsTask : Task.Task Hue.Error (List Hue.Lights.LightDetails)
+listLightsTask =
+    Hue.listLights myBridge
+        |> Task.map (Debug.log "light details")
+        >> Task.mapError (Debug.log "an error occured")
+
+
+listLightsCmd : Cmd Msg
+listLightsCmd =
+    Task.perform (always Noop) (always Noop) listLightsTask
+
+
+
+-- This is how you blink the lights
+
+
+turnOnTask =
+    Hue.updateLight myLight [ Hue.turnOn ]
+        |> Task.map (Debug.log "turned light on")
+        >> Task.mapError (Debug.log "an error occured")
+
+
+turnOffTask =
+    Hue.updateLight myLight [ Hue.turnOff ]
+        |> Task.map (Debug.log "turned light off")
+        >> Task.mapError (Debug.log "an error occured")
+
+
+turnOnCmd : Cmd Msg
+turnOnCmd =
+    Task.perform (always Noop) (always Noop) turnOnTask
+
+
+turnOffCmd : Cmd Msg
+turnOffCmd =
+    Task.perform (always Noop) (always Noop) turnOffTask
+
+
+toggleEvery4Seconds : Sub Msg
+toggleEvery4Seconds =
+    Time.every (4 * Time.second) (always ToggleCmd)
+
+
+
+-- Boilerplate to set up an application that blinks a light.
+
+
+type alias Model =
+    { willTurnOn : Bool
+    }
+
+
+type Msg
+    = Noop
+    | ToggleCmd
+
+
+update msg model =
+    case msg of
+        Noop ->
+            ( model, Cmd.none )
+
+        ToggleCmd ->
+            let
+                cmd =
+                    if model.willTurnOn then
+                        turnOnCmd
+                    else
+                        turnOffCmd
+            in
+                ( { willTurnOn = not model.willTurnOn }, cmd )
+
+
+main : Program Never
+main =
+    program
+        { init = ( { willTurnOn = True }, listLightsCmd )
+        , update = update
+        , view = (\_ -> text "Configure your bridge details, then open your developer tools and see your light details")
+        , subscriptions = always toggleEvery4Seconds
+        }


### PR DESCRIPTION
I've noticed that the example page was still referencing Elm 0.16 code that wouldn't run in Elm 0.17 anymore. So I created a working example and then copied the explanation to the realm from there.

I hope that this makes it easier to get started with this module.
