### PR TITLE
Minimum bridge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,7 @@ toggleEvery4Seconds =
 `example` folder.
 - Check out the other functions on the [Hue module](http://package.elm-lang.org/packages/damienklinnert/elm-hue/latest/Hue)
 - build yourself a powerful UI for controling your own lights.
+
+### Notes
+
+- Minimum Hue Bridge version supported is v1.4

--- a/src/Hue.elm
+++ b/src/Hue.elm
@@ -86,9 +86,10 @@ type alias LightDetails =
     { id : String
     , name : String
     , uniqueId : String
+    , luminaireUniqueId : Maybe String
     , bulbType : String
     , modelId : String
-    , manufacturerName : String
+    , manufacturerName : Maybe String
     , softwareVersion : String
     }
 
@@ -371,6 +372,7 @@ mapLightDetails details =
         details.id
         details.name
         details.uniqueId
+        details.luminaireUniqueId
         details.bulbType
         details.modelId
         details.manufacturerName

--- a/src/Hue/Lights/Decoders.elm
+++ b/src/Hue/Lights/Decoders.elm
@@ -8,23 +8,25 @@ type alias LightDetails =
     { id : String
     , name : String
     , uniqueId : String
+    , luminaireUniqueId : Maybe String
     , bulbType : String
     , modelId : String
-    , manufacturerName : String
+    , manufacturerName : Maybe String
     , softwareVersion : String
     }
 
 
 detailsDecoder : JD.Decoder LightDetails
 detailsDecoder =
-    JD.object7
+    JD.object8
         LightDetails
         (JD.succeed "")
         ("name" := JD.string)
         ("uniqueid" := JD.string)
+        (JD.maybe ("luminaireuniqueid" := JD.string))
         ("type" := JD.string)
         ("modelid" := JD.string)
-        ("manufacturername" := JD.string)
+        (JD.maybe ("manufacturername" := JD.string))
         ("swversion" := JD.string)
 
 

--- a/tests/src/Resource/Lights.elm
+++ b/tests/src/Resource/Lights.elm
@@ -1,8 +1,8 @@
 module Resource.Lights exposing (..)
 
 
-getAllLights__1_0 : String
-getAllLights__1_0 =
+getAllLights__1_4 : String
+getAllLights__1_4 =
     """
     {
         "1": {
@@ -21,6 +21,7 @@ getAllLights__1_0 =
             "type": "Extended color light",
             "name": "Hue Lamp 1",
             "modelid": "LCT001",
+            "uniqueid": "00:17:88:01:00:b6:5c:44-0c",
             "swversion": "66009461",
             "pointsymbol": {
                 "1": "none",
@@ -49,6 +50,7 @@ getAllLights__1_0 =
             "type": "Extended color light",
             "name": "Hue Lamp 2",
             "modelid": "LCT001",
+            "uniqueid": "00:17:88:01:00:b6:52:32-0c",
             "swversion": "66009461",
             "pointsymbol": {
                 "1": "none",
@@ -60,6 +62,193 @@ getAllLights__1_0 =
                 "7": "none",
                 "8": "none"
             }
+        }
+    }
+    """
+
+
+getAllLights__1_7 : String
+getAllLights__1_7 =
+    """
+    {
+        "1": {
+            "state": {
+                "on": true,
+                "bri": 144,
+                "hue": 13088,
+                "sat": 212,
+                "xy": [0.5128,0.4147],
+                "ct": 467,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "xy",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 1",
+            "modelid": "LCT001",
+            "manufacturername": "Philips",
+            "uniqueid": "00:17:88:01:00:b6:5c:44-0c",
+            "swversion": "66009461",
+            "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+            }
+        },
+        "2": {
+            "state": {
+                "on": false,
+                "bri": 0,
+                "hue": 0,
+                "sat": 0,
+                "xy": [0,0],
+                "ct": 0,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "hs",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 2",
+            "modelid": "LCT001",
+            "manufacturername": "Philips",
+            "uniqueid": "00:17:88:01:00:b6:52:32-0c",
+            "swversion": "66009461",
+            "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+            }
+        }
+    }
+    """
+
+
+getAllLights__1_9 : String
+getAllLights__1_9 =
+    """
+    {
+        "1": {
+            "state": {
+                "on": true,
+                "bri": 144,
+                "hue": 13088,
+                "sat": 212,
+                "xy": [0.5128,0.4147],
+                "ct": 467,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "xy",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 1",
+            "modelid": "LCT001",
+            "manufacturername": "Philips",
+            "uniqueid": "00:17:88:01:00:b6:5c:44-0c",
+            "luminaireuniqueid": "00:17:88:99-01-01",
+            "swversion": "66009461",
+            "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+            }
+        },
+        "2": {
+            "state": {
+                "on": false,
+                "bri": 0,
+                "hue": 0,
+                "sat": 0,
+                "xy": [0,0],
+                "ct": 0,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "hs",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 2",
+            "modelid": "LCT001",
+            "manufacturername": "Philips",
+            "uniqueid": "00:17:88:01:00:b6:52:32-0c",
+            "luminaireuniqueid": "00:17:88:99-02-02",
+            "swversion": "66009461",
+            "pointsymbol": {
+                "1": "none",
+                "2": "none",
+                "3": "none",
+                "4": "none",
+                "5": "none",
+                "6": "none",
+                "7": "none",
+                "8": "none"
+            }
+        }
+    }
+    """
+
+
+getAllLights__1_11 : String
+getAllLights__1_11 =
+    """
+    {
+        "1": {
+            "state": {
+                "on": true,
+                "bri": 144,
+                "hue": 13088,
+                "sat": 212,
+                "xy": [0.5128,0.4147],
+                "ct": 467,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "xy",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 1",
+            "modelid": "LCT001",
+            "manufacturername": "Philips",
+            "uniqueid": "00:17:88:01:00:b6:5c:44-0c",
+            "luminaireuniqueid": "00:17:88:99-02-02",
+            "swversion": "66009461"
+        },
+        "2": {
+            "state": {
+                "on": false,
+                "bri": 0,
+                "hue": 0,
+                "sat": 0,
+                "xy": [0,0],
+                "ct": 0,
+                "alert": "none",
+                "effect": "none",
+                "colormode": "hs",
+                "reachable": true
+            },
+            "type": "Extended color light",
+            "name": "Hue Lamp 2",
+            "modelid": "LCT001",
+            "manufacturername": "Philips",
+            "uniqueid": "00:17:88:01:00:b6:52:32-0c",
+            "swversion": "66009461"
         }
     }
     """

--- a/tests/src/Tests/Lights.elm
+++ b/tests/src/Tests/Lights.elm
@@ -25,8 +25,14 @@ getAllLightsTest =
                     fail e
     in
         suite "Get all lights"
-            [ test "Version 1.0 with multiple lights"
-                <| testDecoder detailsListDecoder getAllLights__1_0
+            [ test "Version 1.4 with multiple lights"
+                <| testDecoder detailsListDecoder getAllLights__1_4
+            , test "Version 1.7 with multiple lights"
+                <| testDecoder detailsListDecoder getAllLights__1_7
+            , test "Version 1.9 with multiple lights"
+                <| testDecoder detailsListDecoder getAllLights__1_9
+            , test "Version 1.11 with multiple lights"
+                <| testDecoder detailsListDecoder getAllLights__1_11
             , test "No lights available"
                 <| testDecoder detailsListDecoder noLights
             ]


### PR DESCRIPTION
- Addresses issues #5, #6 
  - Use bridge version 1.4 as a minimum supported bridge version
  - Add passing decoding tests for versions 1.4 - current 1.13
  - Update LightDetails type
    - Use `Maybe` for optional properties
    - Add `luminaireuniqueid` property, which can appear on certain light types on version 1.9+
