### PR TITLE
Support bridge errors in responses

### DIFF
--- a/src/Hue/Lights/Decoders.elm
+++ b/src/Hue/Lights/Decoders.elm
@@ -1,7 +1,38 @@
-module Hue.Lights.Decoders exposing (..)
+module Hue.Lights.Decoders
+    exposing
+        ( Response(..)
+        , LightDetails
+        , detailsResponseDecoder
+        , detailsListResponseDecoder
+        , LightState
+        , stateResponseDecoder
+        , LightEffect(..)
+        , effectResponseDecoder
+        , Alert(..)
+        , alertResponseDecoder
+        , Error
+        , Success
+        , SuccessOrError(..)
+        , multiResponse
+        )
 
 import Json.Decode as JD
 import Json.Decode exposing ((:=))
+
+
+type Response a
+    = ErrorsResponse (List Error)
+    | ValidResponse a
+
+
+{- Helper function that decodes either a list of errors or a response decoder
+ -}
+responseDecoder : JD.Decoder a -> JD.Decoder (Response a)
+responseDecoder responseDecoder =
+    JD.oneOf
+        [ JD.map ValidResponse responseDecoder
+        , JD.map ErrorsResponse errorsDecoder
+        ]
 
 
 type alias LightDetails =
@@ -30,9 +61,19 @@ detailsDecoder =
         ("swversion" := JD.string)
 
 
+detailsResponseDecoder : JD.Decoder (Response LightDetails)
+detailsResponseDecoder =
+    responseDecoder detailsDecoder
+
+
 detailsListDecoder : JD.Decoder (List LightDetails)
 detailsListDecoder =
     JD.keyValuePairs detailsDecoder |> JD.map (List.map (\( id, m ) -> { m | id = id }))
+
+
+detailsListResponseDecoder : JD.Decoder (Response (List LightDetails))
+detailsListResponseDecoder =
+    responseDecoder detailsListDecoder
 
 
 type alias LightState =
@@ -61,6 +102,11 @@ stateDecoder =
         (JD.at [ "state", "reachable" ] JD.bool)
 
 
+stateResponseDecoder : JD.Decoder (Response LightState)
+stateResponseDecoder =
+    responseDecoder stateDecoder
+
+
 type LightEffect
     = NoLightEffect
     | ColorLoopEffect
@@ -81,6 +127,11 @@ effectDecoder =
                     Debug.crash "Received unexpected light effect"
         )
         JD.string
+
+
+effectResponseDecoder : JD.Decoder (Response LightEffect)
+effectResponseDecoder =
+    responseDecoder effectDecoder
 
 
 type Alert
@@ -107,3 +158,83 @@ alertDecoder =
                     Debug.crash "Received unknown light alert"
         )
         JD.string
+
+
+alertResponseDecoder : JD.Decoder (Response Alert)
+alertResponseDecoder =
+    responseDecoder alertDecoder
+
+
+type alias Error =
+    { type' : Int
+    , address : String
+    , description : String
+    }
+
+
+errorDecoder : JD.Decoder Error
+errorDecoder =
+    JD.at [ "error" ] <|
+        JD.object3
+            Error
+            ("type" := JD.int)
+            ("address" := JD.string)
+            ("description" := JD.string)
+
+
+errorsDecoder : JD.Decoder (List Error)
+errorsDecoder =
+    JD.list errorDecoder
+
+
+type alias Success =
+    { command : String }
+
+
+{- Decodes a successful response command in the form of
+   [ {"success":{ any string url : any value type } } ]
+
+   parses the "success" and returns the key url.
+-}
+successDecoder : JD.Decoder Success
+successDecoder =
+    let
+        -- Possible success response types
+        allTypesDecoder =
+            JD.oneOf
+                [ JD.map toString JD.string
+                , JD.map toString JD.bool
+                , JD.map toString JD.int
+                , JD.map toString JD.float
+                , JD.map toString (JD.list JD.float)
+                ]
+
+        firstValue valuePairs =
+            case List.head valuePairs of
+                Just pair ->
+                    fst pair
+                        |> Success
+                        |> JD.succeed
+
+                Nothing ->
+                    -- Could not parse value, but it was still a Success response object
+                    JD.succeed (Success "unknown")
+    in
+        JD.keyValuePairs allTypesDecoder `JD.andThen` firstValue |> JD.at [ "success" ]
+
+
+type SuccessOrError
+    = SuccessValue Success
+    | ErrorValue Error
+
+
+
+{- A response of a list that may contain errors and success values
+ -}
+multiResponse : JD.Decoder (List SuccessOrError)
+multiResponse =
+    JD.list <|
+        JD.oneOf
+            [ JD.map ErrorValue errorDecoder
+            , JD.map SuccessValue successDecoder
+            ]

--- a/tests/src/Resource/Lights.elm
+++ b/tests/src/Resource/Lights.elm
@@ -1,6 +1,9 @@
 module Resource.Lights exposing (..)
 
 
+-- Get List of Lights
+
+
 getAllLights__1_4 : String
 getAllLights__1_4 =
     """
@@ -258,4 +261,161 @@ noLights : String
 noLights =
     """
     {}
+    """
+
+
+-- Light details
+
+
+
+lightState__1_4 : String
+lightState__1_4 =
+    """
+    {
+        "state": {
+            "hue": 50000,
+            "on": true,
+            "effect": "none",
+            "alert": "none",
+            "bri": 200,
+            "sat": 200,
+            "ct": 500,
+            "xy": [0.5, 0.5],
+            "reachable": true,
+            "colormode": "hs"
+        },
+        "type": "Living Colors",
+        "name": "LC 1",
+        "modelid": "LC0015",
+        "swversion": "1.0.3",
+        "pointsymbol": {
+            "1": "none",
+            "2": "none",
+            "3": "none",
+            "4": "none",
+            "5": "none",
+            "6": "none",
+            "7": "none",
+            "8": "none"
+        }
+    }
+    """
+
+lightState__1_11 : String
+lightState__1_11 =
+    """
+    {
+        "state": {
+            "hue": 50000,
+            "on": true,
+            "effect": "none",
+            "alert": "none",
+            "bri": 200,
+            "sat": 200,
+            "ct": 500,
+            "xy": [0.5, 0.5],
+            "reachable": true,
+            "colormode": "hs"
+        },
+        "type": "Living Colors",
+        "name": "LC 1",
+        "modelid": "LC0015",
+        "swversion": "1.0.3"
+    }
+    """
+
+
+-- Errors and Successes
+
+
+
+invalidAuthError : String
+invalidAuthError =
+    """
+    [
+        {
+            "error": {
+            "type": 1,
+            "address": "/lights",
+            "description": "unauthorized user"
+            }
+        }
+    ]
+    """
+
+
+multiSuccessAndErrorLightUpdateResponse : String
+multiSuccessAndErrorLightUpdateResponse =
+    """
+    [
+        {
+            "error": {
+                "type": 201,
+                "address": "/lights/1/state/sat",
+                "description": "parameter, sat, is not modifiable. Device is set to off."
+            }
+        },
+        {
+            "error": {
+                "type": 201,
+                "address": "/lights/1/state/bri",
+                "description": "parameter, bri, is not modifiable. Device is set to off."
+            }
+        },
+        {
+            "success": {
+                "/lights/1/state/on": false
+            }
+        }
+    ]
+    """
+
+singleSuccessLightUpdateResponse : String
+singleSuccessLightUpdateResponse =
+    """
+    [
+        {"success":{"/lights/1/state/on":true}}
+    ]
+    """
+
+
+multiSuccessLightUpdateResponse : String
+multiSuccessLightUpdateResponse =
+    """
+    [
+        {"success":{"/lights/1/state/bri":200}},
+        {"success":{"/lights/1/state/on":true}},
+        {"success":{"/lights/1/state/hue":50000}}
+    ]
+    """
+
+
+allSuccessLightUpdateResponseTypes : String
+allSuccessLightUpdateResponseTypes =
+    """
+    [
+        {
+            "success": {
+                "/lights/1/state/on": true
+            }
+        },
+        {
+            "success": {
+                "/lights/1/state/sat": 254
+            }
+        },
+        {
+            "success": {
+                "/lights/1/state/xy": [
+                    0.5,
+                    0.5
+                ]
+            }
+        },
+        {
+            "success": {
+                "/lights/1/state/alert": "none"
+            }
+        }
+    ]
     """

--- a/tests/src/Tests/Lights.elm
+++ b/tests/src/Tests/Lights.elm
@@ -10,29 +10,60 @@ tests : Test
 tests =
     suite "Lights decoding"
         [ getAllLightsTest
+        , getLightStateTest
+        , updateLightResponseTest
         ]
+
+testDecoder : JD.Decoder a -> String -> Assertion
+testDecoder decoder str =
+    case JD.decodeString decoder str of
+        Ok _ ->
+            pass
+
+        Err e ->
+            fail e
 
 
 getAllLightsTest : Test
 getAllLightsTest =
-    let
-        testDecoder decoder str =
-            case JD.decodeString decoder str of
-                Ok _ ->
-                    pass
+    suite "Get all lights"
+        [ test "Version 1.4 with multiple lights"
+            <| testDecoder detailsListResponseDecoder getAllLights__1_4
+        , test "Version 1.7 with multiple lights"
+            <| testDecoder detailsListResponseDecoder getAllLights__1_7
+        , test "Version 1.9 with multiple lights"
+            <| testDecoder detailsListResponseDecoder getAllLights__1_9
+        , test "Version 1.11 with multiple lights"
+            <| testDecoder detailsListResponseDecoder getAllLights__1_11
+        , test "No lights available"
+            <| testDecoder detailsListResponseDecoder noLights
+        , test "Authentication error when fetching all lights"
+            <| testDecoder detailsListResponseDecoder invalidAuthError
+        ]
 
-                Err e ->
-                    fail e
-    in
-        suite "Get all lights"
-            [ test "Version 1.4 with multiple lights"
-                <| testDecoder detailsListDecoder getAllLights__1_4
-            , test "Version 1.7 with multiple lights"
-                <| testDecoder detailsListDecoder getAllLights__1_7
-            , test "Version 1.9 with multiple lights"
-                <| testDecoder detailsListDecoder getAllLights__1_9
-            , test "Version 1.11 with multiple lights"
-                <| testDecoder detailsListDecoder getAllLights__1_11
-            , test "No lights available"
-                <| testDecoder detailsListDecoder noLights
-            ]
+getLightStateTest : Test
+getLightStateTest =
+    suite "Get Light state"
+        [ test "Version 1.4"
+            <| testDecoder stateResponseDecoder lightState__1_4
+        , test "Version 1.11"
+            <| testDecoder stateResponseDecoder lightState__1_11
+        , test "Auth error"
+            <| testDecoder stateResponseDecoder invalidAuthError
+        ]
+
+
+updateLightResponseTest : Test
+updateLightResponseTest =
+    suite "Parse light update response"
+        [ test "Multi error and success response"
+            <| testDecoder multiResponse multiSuccessAndErrorLightUpdateResponse
+        , test "Single successful response"
+            <| testDecoder multiResponse singleSuccessLightUpdateResponse
+        , test "Multiple successful responses"
+            <| testDecoder multiResponse multiSuccessLightUpdateResponse
+        , test "All success value types"
+            <| testDecoder multiResponse allSuccessLightUpdateResponseTypes
+        , test "Single error response"
+            <| testDecoder multiResponse invalidAuthError
+        ]


### PR DESCRIPTION
- Implement #8
- Add decoding unit tests
- Update example to show example error destructuring 

Opened this into a feature branch as this has some large changes, and we might we want to keep refining things. 
#### Further considerations
- It might be a good idea to move errors into a separate exposed module
- Some of the method definitions are a little long. 
  - `Task Hue.BridgeReferenceError (Result (List Hue.GenericError) (List Hue.LightDetails))`
    
    There might be a nice way to shorten this with type aliases
